### PR TITLE
[Feature] Special Events Tracking (die of doom)

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -20,10 +20,11 @@
   1. Tracker
   2. Creature
   3. Effect
+  4. Special Event (Die of Doom)
 
 **More on Tracker Class**
   - tracks of round (counter)
-  - tracks whose turn it is (first element in array)
+  - tracks current turn (first element in array)
   - tracks initative order (array)
   - Sorts initiative order by initative roll
   - adds combantants to intitative order
@@ -45,6 +46,12 @@
   - tracks duration
   - has a description
   - tracks creature it belongs to
+
+**More on Special Events Class**
+- tracks name
+- tracks description
+- tracks frequency
+- tracks tracker it belongs to
 
 **Manual Testing with CURL commands**
 Trackers Controller
@@ -142,10 +149,9 @@ curl -X PATCH http://localhost:3000/trackers/:tracker_id/creatures/:creature_id/
 ```
 
 **Todo**
-  - Death Saves Counter (optional???)
-  - Die of Doom tracker (Special Event)
   - Special Abilities worth tracking (Multi attack, 15ft. reach, etc.)
   - Add Enemies on the fly (new controller, tests, fixtures)
+  - Dry out test suite, use more fixtures
   - External Facing API
   - Make CSV Import for easy combat setup
   - Make CSV Log Export for useful post combat data

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -151,7 +151,10 @@ curl -X PATCH http://localhost:3000/trackers/:tracker_id/creatures/:creature_id/
 **Todo**
   - Special Abilities worth tracking (Multi attack, 15ft. reach, etc.)
   - Add Enemies on the fly (new controller, tests, fixtures)
+  - Allow trackers to have a name attr
   - Dry out test suite, use more fixtures
+  - Apply up + down methods to migrations
+  - model validations vs. migrations
   - External Facing API
   - Make CSV Import for easy combat setup
   - Make CSV Log Export for useful post combat data

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -147,15 +147,43 @@ curl -X PATCH http://localhost:3000/trackers/:tracker_id/creatures/:creature_id/
     }
   }'
 ```
+Special Events Controller
+```bash
+curl -X GET http://localhost:3000/special_events
+curl -X GET http://localhost:3000/special_events/:special_event_id
+curl -X DELETE http://localhost:3000/special_events/:special_event_id
+
+curl -X POST http://localhost:3000/special_events \
+  -H "Content-Type: application/json" \
+  -d '{
+    "special_event": {
+      "name": "Solar Flare",
+      "description": "A massive flare affects all combatants.",
+      "frequency": 1,
+      "tracker_id": null
+    }
+  }'
+
+curl -X PUT http://localhost:3000/special_events/:special_event_id \
+  -H "Content-Type: application/json" \
+  -d '{
+    "special_event": {
+      "name": "Updated Event Name",
+      "description": "New description here.",
+      "frequency": 2
+    }
+  }'
+```
 
 **Todo**
   - Special Abilities worth tracking (Multi attack, 15ft. reach, etc.)
   - Add Enemies on the fly (new controller, tests, fixtures)
   - Allow trackers to have a name attr
+  - FE: Landing page, Tracker Show Page, etc...
   - Dry out test suite, use more fixtures
   - Apply up + down methods to migrations
   - model validations vs. migrations
-  - External Facing API
+  - Buildout External facing API for CSV Exports/Imports
   - Make CSV Import for easy combat setup
   - Make CSV Log Export for useful post combat data
   - Make readme for CSV Import/Export

--- a/app/controllers/special_events_controller.rb
+++ b/app/controllers/special_events_controller.rb
@@ -1,0 +1,52 @@
+class SpecialEventsController < ApplicationController
+  before_action :set_special_event, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @special_events = SpecialEvent.all #WIP...
+    render json: @special_events
+  end
+
+  def show
+    render json: @special_event
+  end
+
+  def create
+    @special_event = SpecialEvent.new(
+      name: special_event_params[:name],
+      description: special_event_params[:description],
+      frequency: special_event_params[:frequency],
+      tracker_id: special_event_params[:tracker_id] || nil
+    )
+    if @special_event.save
+      redirect_to @special_event, notice: "Special event created."
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @special_event.update(special_event_params)
+      redirect_to @special_event, notice: "Special event updated."
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @special_event.destroy
+    redirect_to special_events_path, notice: "Special event deleted."
+  end
+
+  private
+
+  def set_special_event
+    @special_event = SpecialEvent.find(params[:id])
+  end
+
+  def special_event_params
+    params.require(:special_event).permit(:name, :description, :frequency, :tracker_id)
+  end
+end

--- a/app/controllers/special_events_controller.rb
+++ b/app/controllers/special_events_controller.rb
@@ -1,8 +1,8 @@
 class SpecialEventsController < ApplicationController
-  before_action :set_special_event, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_special_event, only: [ :show, :update, :destroy ]
 
   def index
-    @special_events = SpecialEvent.all #WIP...
+    @special_events = SpecialEvent.all
     render json: @special_events
   end
 
@@ -11,33 +11,26 @@ class SpecialEventsController < ApplicationController
   end
 
   def create
-    @special_event = SpecialEvent.new(
-      name: special_event_params[:name],
-      description: special_event_params[:description],
-      frequency: special_event_params[:frequency],
-      tracker_id: special_event_params[:tracker_id] || nil
-    )
-    if @special_event.save
-      redirect_to @special_event, notice: "Special event created."
-    else
-      render :new
-    end
-  end
+    @special_event = SpecialEvent.new(special_event_params)
 
-  def edit
+    if @special_event.save
+      render json: @special_event, status: :created
+    else
+      render json: @special_event.errors, status: :unprocessable_entity
+    end
   end
 
   def update
     if @special_event.update(special_event_params)
-      redirect_to @special_event, notice: "Special event updated."
+      render json: @special_event
     else
-      render :edit
+      render json: @special_event.errors, status: :unprocessable_entity
     end
   end
 
   def destroy
     @special_event.destroy
-    redirect_to special_events_path, notice: "Special event deleted."
+    head :no_content  # returns a 204 No Content response
   end
 
   private

--- a/app/helpers/special_events_helper.rb
+++ b/app/helpers/special_events_helper.rb
@@ -1,0 +1,2 @@
+module SpecialEventsHelper
+end

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -1,0 +1,3 @@
+class SpecialEvent < ApplicationRecord
+  belongs_to :tracker
+end

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -1,3 +1,7 @@
 class SpecialEvent < ApplicationRecord
-  belongs_to :tracker
+  belongs_to :tracker, optional: true
+
+  validates :name, presence: true
+  validates :description, presence: true
+  validates :frequency, presence: true
 end

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -1,7 +1,7 @@
 class SpecialEvent < ApplicationRecord
   belongs_to :tracker, optional: true
 
-  validates :name, presence: true
-  validates :description, presence: true
-  validates :frequency, presence: true
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :description, presence: true, length: { maximum: 500 }
+  validates :frequency, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 end

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -29,8 +29,8 @@ class Tracker < ApplicationRecord
   end
 
   def trigger_special_events
-    tracker.special_events.each do |event|
-      if tracker.round % event.frequency == 0
+    special_events.each do |event|
+      if self.round % event.frequency == 0
         puts "Special Event Trigged: #{event.name}"
       end
     end

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -1,5 +1,6 @@
 class Tracker < ApplicationRecord
   has_many :creatures
+  has_many :special_events
 
   serialize :turn_order, coder: YAML
 
@@ -27,9 +28,18 @@ class Tracker < ApplicationRecord
     save!
   end
 
+  def trigger_special_events
+    tracker.special_events.each do |event|
+      if tracker.round % event.frequency == 0
+        puts "Special Event Trigged: #{event.name}"
+      end
+    end
+  end
+
   def next_round
     self.mark_active_turn
     self.round += 1
     save!
+    trigger_special_events
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :effects, only: [ :index, :show, :create, :update, :destroy ]
+  resources :special_events, only: [ :index, :show, :create, :update, :destroy ]
 
   resources :trackers, only: [ :create, :show, :update ] do
     member do

--- a/db/migrate/20250428215823_create_special_events.rb
+++ b/db/migrate/20250428215823_create_special_events.rb
@@ -1,0 +1,12 @@
+class CreateSpecialEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :special_events do |t|
+      t.string :name
+      t.text :description
+      t.integer :frequency
+      t.integer :tracker_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250428221419_create_special_events.rb
+++ b/db/migrate/20250428221419_create_special_events.rb
@@ -1,10 +1,10 @@
-class CreateSpecialEvents < ActiveRecord::Migration[8.0]
+class CreateSpecialEvents < ActiveRecord::Migration[7.0]
   def change
     create_table :special_events do |t|
       t.string :name
       t.text :description
       t.integer :frequency
-      t.integer :tracker_id
+      t.references :tracker, foreign_key: true, null: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_25_214956) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_28_215823) do
   create_table "creatures", force: :cascade do |t|
     t.string "name"
     t.string "role"
@@ -36,6 +36,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_25_214956) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creature_id"], name: "index_effects_on_creature_id"
+  end
+
+  create_table "special_events", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.integer "frequency"
+    t.integer "tracker_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "trackers", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_28_215823) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_28_221419) do
   create_table "creatures", force: :cascade do |t|
     t.string "name"
     t.string "role"
@@ -45,6 +45,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_215823) do
     t.integer "tracker_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["tracker_id"], name: "index_special_events_on_tracker_id"
   end
 
   create_table "trackers", force: :cascade do |t|
@@ -56,4 +57,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_215823) do
 
   add_foreign_key "creatures", "trackers"
   add_foreign_key "effects", "creatures"
+  add_foreign_key "special_events", "trackers"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,11 +2,12 @@
 Tracker.destroy_all
 Creature.destroy_all
 Effect.destroy_all
+SpecialEvent.destroy_all
 
-# Create Tracker (Global)
+# Trackers (Global)
 tracker = Tracker.create!(round: 1, turn_order: [])
 
-# Create Effect (Global)
+# Effects (Global)
 effect1 = Effect.create!(
   name: "Chill Wind",
   description: "A cold gust that slows enemies.",
@@ -28,7 +29,7 @@ effect3 = Effect.create!(
   status_type: "debuff"
 )
 
-# Create Creatures (Global)
+# Creatures (Global)
 creatures = [
   { name: "Aragorn", role: "player", initiative: rand(1..20), dead: false, current_hp: 15, max_hp: 15, temp_hp: 0 },
   { name: "Gandalf", role: "player", initiative: rand(1..20), dead: false, current_hp: 12, max_hp: 12, temp_hp: 0 },
@@ -37,7 +38,13 @@ creatures = [
   { name: "Villager of Bywater", role: "npc", initiative: rand(1..20), dead: false, current_hp: 35, max_hp: 35, temp_hp: 0 }
 ]
 
-# Save creatures and add their IDs to the tracker's turn order
+# Special Events (Global)
+SpecialEvent.create(name: "Blizzard", description: "Bone chilling winds and heavy snow", frequency: 30)
+
+# Add special event to tracker
+SpecialEvent.create(name: "Toxic Mist", description: "Poison Mist, Con save DC 11", frequency: 15, tracker: tracker)
+
+# Add creatures to tracker
 creatures.each do |creature_data|
   creature = Creature.create!(creature_data.merge(tracker: tracker))
   tracker.turn_order << creature.id
@@ -47,4 +54,4 @@ end
 tracker.sort_turn_order
 tracker.save!
 
-puts "Seeded creature(s): #{Creature.count}, tracker(s): #{Tracker.count}, effect(s): #{Effect.count}!"
+puts "Seeded creature(s): #{Creature.count}, tracker(s): #{Tracker.count}, effect(s): #{Effect.count}, special event(s): #{SpecialEvent.count}!"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,10 +39,10 @@ creatures = [
 ]
 
 # Special Events (Global)
-SpecialEvent.create(name: "Blizzard", description: "Bone chilling winds and heavy snow", frequency: 30)
+SpecialEvent.create!(name: "Blizzard", description: "Bone chilling winds and heavy snow", frequency: 30)
 
 # Add special event to tracker
-SpecialEvent.create(name: "Toxic Mist", description: "Poison Mist, Con save DC 11", frequency: 15, tracker: tracker)
+SpecialEvent.create!(name: "Toxic Mist", description: "Poison Mist, Con save DC 11", frequency: 15, tracker: tracker)
 
 # Add creatures to tracker
 creatures.each do |creature_data|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,26 +8,32 @@ SpecialEvent.destroy_all
 tracker = Tracker.create!(round: 1, turn_order: [])
 
 # Effects (Global)
-effect1 = Effect.create!(
+Effect.create!(
   name: "Chill Wind",
   description: "A cold gust that slows enemies.",
   duration: 3,
   status_type: "debuff"
 )
 
-effect2 = Effect.create!(
+Effect.create!(
   name: "Hero's Blessing",
   description: "Increases strength and morale.",
   duration: 5,
   status_type: "buff"
 )
 
-effect3 = Effect.create!(
+Effect.create!(
   name: "Lingering Poison",
   description: "Deals damage over time.",
   duration: 4,
   status_type: "debuff"
 )
+
+# Special Events (Global)
+SpecialEvent.create!(name: "Blizzard", description: "Bone chilling winds and heavy snow", frequency: 30)
+
+# Add special event to tracker
+SpecialEvent.create!(name: "Toxic Mist", description: "Poison Mist, Con save DC 11", frequency: 15, tracker: tracker)
 
 # Creatures (Global)
 creatures = [
@@ -37,12 +43,6 @@ creatures = [
   { name: "The Pale Orc", role: "monster", initiative: rand(1..20), dead: false, current_hp: 25, max_hp: 25, temp_hp: 0 },
   { name: "Villager of Bywater", role: "npc", initiative: rand(1..20), dead: false, current_hp: 35, max_hp: 35, temp_hp: 0 }
 ]
-
-# Special Events (Global)
-SpecialEvent.create!(name: "Blizzard", description: "Bone chilling winds and heavy snow", frequency: 30)
-
-# Add special event to tracker
-SpecialEvent.create!(name: "Toxic Mist", description: "Poison Mist, Con save DC 11", frequency: 15, tracker: tracker)
 
 # Add creatures to tracker
 creatures.each do |creature_data|

--- a/test/controllers/special_events_controller_test.rb
+++ b/test/controllers/special_events_controller_test.rb
@@ -1,7 +1,53 @@
 require "test_helper"
 
 class SpecialEventsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @event = special_events(:meteor_swarm)
+  end
+
+  test "should get index" do
+    get special_events_url, as: :json
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_includes body.map { |e| e["id"] }, @event.id
+  end
+
+  test "should show special_event" do
+    get special_event_url(@event), as: :json
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal @event.name, body["name"]
+  end
+
+  test "should create special_event" do
+    assert_difference("SpecialEvent.count") do
+      post special_events_url, params: {
+        special_event: {
+          name: "New Event",
+          description: "A new global event",
+          frequency: 5
+        }
+      }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should update special_event" do
+    patch special_event_url(@event), params: {
+      special_event: { frequency: 20 }
+    }, as: :json
+
+    assert_response :success
+    @event.reload
+    assert_equal 20, @event.frequency
+  end
+
+  test "should destroy special_event" do
+    assert_difference("SpecialEvent.count", -1) do
+      delete special_event_url(@event), as: :json
+    end
+
+    assert_response :no_content
+  end
 end

--- a/test/controllers/special_events_controller_test.rb
+++ b/test/controllers/special_events_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SpecialEventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/special_events.yml
+++ b/test/fixtures/special_events.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyText
+  frequency: 1
+  tracker: one
+
+two:
+  name: MyString
+  description: MyText
+  frequency: 1
+  tracker: two

--- a/test/fixtures/special_events.yml
+++ b/test/fixtures/special_events.yml
@@ -1,13 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  description: MyText
-  frequency: 1
+meteor_swarm:
+  name: Meteor Swarm
+  description: 50ft radius, 10d10 + 40 fire damage 
+  frequency: 5
   tracker: one
 
-two:
-  name: MyString
-  description: MyText
+fire_storm:
+  name: Fire Storm
+  description: 20ft radius, 5d6 fire damage per turn
   frequency: 1
   tracker: two

--- a/test/models/special_event_test.rb
+++ b/test/models/special_event_test.rb
@@ -1,7 +1,73 @@
 require "test_helper"
 
 class SpecialEventTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @valid_attributes = {
+      name: "Test Event",
+      description: "This is a test event.",
+      frequency: 5
+    }
+  end
+
+  test "is valid with valid attributes" do
+    event = SpecialEvent.new(@valid_attributes)
+    assert event.valid?
+  end
+
+  test "is invalid without a name" do
+    event = SpecialEvent.new(@valid_attributes.merge(name: nil))
+    assert_not event.valid?
+    assert_includes event.errors[:name], "can't be blank"
+  end
+
+  test "is invalid with a name longer than 100 characters" do
+    long_name = "a" * 101
+    event = SpecialEvent.new(@valid_attributes.merge(name: long_name))
+    assert_not event.valid?
+    assert_includes event.errors[:name], "is too long (maximum is 100 characters)"
+  end
+
+  test "is invalid without a description" do
+    event = SpecialEvent.new(@valid_attributes.merge(description: nil))
+    assert_not event.valid?
+    assert_includes event.errors[:description], "can't be blank"
+  end
+
+  test "is invalid with a description longer than 500 characters" do
+    long_description = "a" * 501
+    event = SpecialEvent.new(@valid_attributes.merge(description: long_description))
+    assert_not event.valid?
+    assert_includes event.errors[:description], "is too long (maximum is 500 characters)"
+  end
+
+  test "is invalid without a frequency" do
+    event = SpecialEvent.new(@valid_attributes.merge(frequency: nil))
+    assert_not event.valid?
+    assert_includes event.errors[:frequency], "can't be blank"
+  end
+
+  test "is invalid with a frequency less than 1" do
+    event = SpecialEvent.new(@valid_attributes.merge(frequency: 0))
+    assert_not event.valid?
+    assert_includes event.errors[:frequency], "must be greater than or equal to 1"
+  end
+
+  test "is invalid with a non-integer frequency" do
+    event = SpecialEvent.new(@valid_attributes.merge(frequency: 2.5))
+    assert_not event.valid?
+    assert_includes event.errors[:frequency], "must be an integer"
+  end
+
+  test "can be associated with a tracker" do
+    tracker = trackers(:one)
+    event = SpecialEvent.new(@valid_attributes.merge(tracker: tracker))
+    assert event.valid?
+    assert_equal tracker, event.tracker
+  end
+
+  test "can exist without a tracker (global event)" do
+    event = SpecialEvent.new(@valid_attributes)
+    assert event.valid?
+    assert_nil event.tracker
+  end
 end

--- a/test/models/special_event_test.rb
+++ b/test/models/special_event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SpecialEventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tracker_test.rb
+++ b/test/models/tracker_test.rb
@@ -74,4 +74,29 @@ class TrackerTest < ActiveSupport::TestCase
     @tracker.mark_active_turn
     assert_not_equal first_id, @tracker.turn_order.first
   end
+
+  test "should trigger special events based on frequency" do
+    SpecialEvent.create!(
+      name: "Storm",
+      description: "A sudden storm hits the battlefield",
+      frequency: 1,
+      tracker: @tracker
+    )
+
+    # Create another event that shouldn't trigger
+    SpecialEvent.create!(
+      name: "Earthquake",
+      description: "Shakes the ground",
+      frequency: 10,
+      tracker: @tracker
+    )
+
+    # Capture the output of puts
+    output = capture_io do
+      @tracker.trigger_special_events
+    end.first
+
+    assert_match /Special Event Trigged: Storm/, output
+    assert_no_match /Earthquake/, output
+  end
 end


### PR DESCRIPTION
**Why?**
- Need to keep track of special events, removes mental overhead for DM
- Setup special events globally for now

**What?**
-  app/models/special_event.rb, added Model
- app/controllers/special_events_controller.rb, added controller
- app/models/tracker.rb, added association with new model + new method that hooks into **#next_round**
- config/routes.rb, added needed routes
- db/migrate/20250428221419_create_special_events.rb, added migration
- db/seeds.rb, added seed data
- Added curl commands to DEV NOTES
- Added unit tests, controller tests and fixtures

**Notes:**
- Controllers are WIP, but built out enough for now
- Controller logic needs to be updated for User login + front end rendering in Rails 8
- May want to have the User add a special event in the middle of combat, 
- Let's put this on another PR as a feature, will need a new controller, tests, etc.